### PR TITLE
Extend travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,42 +9,42 @@ matrix:
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-5']
-      env: COMPILER=g++-5 CPPVERFLAG=-std=c++17
+      env: COMPILER=g++-5 CPPVERFLAG=-std=c++14
 
     - compiler: gcc
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-6']
-      env: COMPILER=g++-6 CPPVERFLAG=-std=c++17
+      env: COMPILER=g++-6 CPPVERFLAG=-std=c++14
 
     - compiler: gcc
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-7']
-      env: COMPILER=g++-7 CPPVERFLAG=-std=c++17
+      env: COMPILER=g++-7 CPPVERFLAG=-std=c++14
 
     - compiler: gcc
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-8']
-      env: COMPILER=g++-8 CPPVERFLAG=-std=c++17
+      env: COMPILER=g++-8 CPPVERFLAG=-std=c++14
 
     - compiler: clang
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.9']
           packages: ['clang-3.9', 'g++-6']
-      env: COMPILER=clang++-3.9 CPPVERFLAG=-std=c++17
+      env: COMPILER=clang++-3.9 CPPVERFLAG=-std=c++14
 
     - compiler: clang
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-7']
           packages: ['clang-7', 'g++-8']
-      env: COMPILER=clang++-7 CPPVERFLAG=-std=c++17
+      env: COMPILER=clang++-7 CPPVERFLAG=-std=c++14
 
 script:
 - cd ./xxhash

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,20 @@ matrix:
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-5']
+      env: COMPILER=g++-5 CPPVERFLAG=-std=c++17
+
+    - compiler: gcc
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-6']
+      env: COMPILER=g++-6 CPPVERFLAG=-std=c++17
+
+    - compiler: gcc
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-7']
       env: COMPILER=g++-7 CPPVERFLAG=-std=c++17
 
@@ -17,6 +31,13 @@ matrix:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-8']
       env: COMPILER=g++-8 CPPVERFLAG=-std=c++17
+
+    - compiler: clang
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-3.9']
+          packages: ['clang-3.9', 'g++-6']
+      env: COMPILER=clang++-3.9 CPPVERFLAG=-std=c++17
 
     - compiler: clang
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: cpp
 os: linux
 dist: trusty
-sudo: required
 
 matrix:
   include:
@@ -10,23 +9,23 @@ matrix:
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-7']
-      env: COMPILER=g++-7 CPPVERFLAG=-std=c++17 EXTRAARGS=" -O3 -march=native -Wall -Wpedantic -Wextra " LIBS=""
+      env: COMPILER=g++-7 CPPVERFLAG=-std=c++17
 
     - compiler: gcc
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['g++-8']
-      env: COMPILER=g++-8 CPPVERFLAG=-std=c++17 EXTRAARGS=" -O3 -march=native -Wall -Wpedantic -Wextra " LIBS=""
+      env: COMPILER=g++-8 CPPVERFLAG=-std=c++17
 
     - compiler: clang
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-7']
           packages: ['clang-7', 'g++-8']
-      env: COMPILER=clang++-7 CPPVERFLAG=-std=c++17 EXTRAARGS=" -O3 -march=native -Wall -Wpedantic -Wextra " LIBS=""
+      env: COMPILER=clang++-7 CPPVERFLAG=-std=c++17
 
 script:
 - cd ./xxhash
-- make CXX=$COMPILER 
+- make CXX=$COMPILER EXTRAARGS=" -O3 -march=native -Wall -Wpedantic -Wextra "
 - ./test

--- a/xxhash/xxhash.hpp
+++ b/xxhash/xxhash.hpp
@@ -348,7 +348,7 @@ namespace xxh
 		constexpr static std::array<hash32_t, 5> primes32 = { 2654435761U, 2246822519U, 3266489917U, 668265263U, 374761393U };
 		constexpr static std::array<hash64_t, 5> primes64 = { 11400714785074694791ULL, 14029467366897019727ULL, 1609587929392839161ULL, 9650029242287828579ULL, 2870177450012600261ULL };
 
-		template <size_t N> 
+		template <size_t N>
 		constexpr hash_t<N> PRIME(int32_t n) {};
 
 		template <>
@@ -488,7 +488,7 @@ namespace xxh
 
 			hash_ret += static_cast<hash_t<N>>(len);
 
-			return endian_align_sub_ending<N>(hash_ret, p, bEnd, endian, align);			
+			return endian_align_sub_ending<N>(hash_ret, p, bEnd, endian, align);
 		}
 	}
 
@@ -546,7 +546,7 @@ namespace xxh
 
 		uint64_t total_len = 0;
 		hash_t<N> v1 = 0, v2 = 0, v3 = 0, v4 = 0;
-		std::array<hash_t<N>, 4> mem = { 0,0,0,0 };
+		std::array<hash_t<N>, 4> mem = {{ 0,0,0,0 }};
 		uint32_t memsize = 0;
 
 		inline error_code _update_impl(const void* input, size_t length, endianness endian)


### PR DESCRIPTION
I simplified the travis.yml a bit and added tests with the minimum supported compilers + C++14 as advertised in the readme.

For clang I did not chose 3.4 but clang 3.9 as this seems the oldest available one on trusty: https://github.com/sylvestre/apt-source-whitelist/blob/master/ubuntu.json