### PR TITLE
fix gcc 14.1 compilation issue

### DIFF
--- a/include/xxhash.hpp
+++ b/include/xxhash.hpp
@@ -1889,22 +1889,16 @@ namespace xxh
 				memsize = 0;
 			}
 
-			if (p <= bEnd - (bit_mode / 2))
+			while (p + (bit_mode / 2) <= bEnd)
 			{
-				const uint8_t* const limit = bEnd - (bit_mode / 2);
-
-				do
-				{
-					v1 = detail::round<bit_mode>(v1, mem_ops::readLE<bit_mode>(p)); 
-					p += (bit_mode / 8);
-					v2 = detail::round<bit_mode>(v2, mem_ops::readLE<bit_mode>(p)); 
-					p += (bit_mode / 8);
-					v3 = detail::round<bit_mode>(v3, mem_ops::readLE<bit_mode>(p)); 
-					p += (bit_mode / 8);
-					v4 = detail::round<bit_mode>(v4, mem_ops::readLE<bit_mode>(p)); 
-					p += (bit_mode / 8);
-				} 
-				while (p <= limit);
+				v1 = detail::round<bit_mode>(v1, mem_ops::readLE<bit_mode>(p)); 
+				p += (bit_mode / 8);
+				v2 = detail::round<bit_mode>(v2, mem_ops::readLE<bit_mode>(p)); 
+				p += (bit_mode / 8);
+				v3 = detail::round<bit_mode>(v3, mem_ops::readLE<bit_mode>(p)); 
+				p += (bit_mode / 8);
+				v4 = detail::round<bit_mode>(v4, mem_ops::readLE<bit_mode>(p)); 
+				p += (bit_mode / 8);
 			}
 
 			if (p < bEnd)


### PR DESCRIPTION
Hello,

The following usage code:

```
#include "xxhash.hpp"

int main(int argc, char** argv) {
  xxh::hash_state_t<64> x;
  for (int i=0;i<argc;++i) {
    uint64_t v=strlen(argv[i]);
    x.update(&v,sizeof(v));
  }
  return x.digest();
}

```
compiled with -O3 and g++ version 14.1.1:

`g++ -Wall -Werror -O3 -isystem/home/rgr/trunk/external/packages/xxHash -c test.cpp -o test.o
`

gives the following compilation error:

```
In file included from test.cpp:1:
In member function ‘void xxh::hash_state_t<bit_mode>::update_impl(const void*, size_t) [with long unsigned int bit_mode = 64]’,
    inlined from ‘void xxh::hash_state_t<bit_mode>::update(const void*, size_t) [with long unsigned int bit_mode = 64]’ at xxhash.hpp:1964:22,
    inlined from ‘int main(int, char**)’ at test.cpp:8:13:
xxhash.hpp:1892:39: error: array subscript -3 is outside array bounds of ‘uint64_t [1]’ {aka ‘long unsigned int [1]’} [-Werror=array-bounds=]
 1892 |                         if (p <= bEnd - (bit_mode / 2))
      |                                  ~~~~~^~~~~~~~~~~~~~~~
test.cpp: In function ‘int main(int, char**)’:
test.cpp:7:14: note: at offset -24 into object ‘v’ of size 8
    7 |     uint64_t v=strlen(argv[i]);
      |              ^

```

The change I propose is just a rewrite of the code that allows the compilation to go through with this g++ 14.1 version. The code was organized with a "if (condition that we have more than n bytes) { do { } while (<condition that we have more than n bytes>)", I suggest to rewrite if "while (rewritten condition that we have more than n bytes) {}". I ran test_scalar and test_sse2 and both ran fine with the change (I'm not able to run avr/x tests myself).

Regards,
  Fabrice