### PR TITLE
fix compilation error (gcc 13.1) with AVX512 activated

### DIFF
--- a/include/xxhash.hpp
+++ b/include/xxhash.hpp
@@ -728,7 +728,7 @@ namespace xxh
 
 			if constexpr (N == 512)
 			{
-				return _mm512_shuffle_epi32(a, _MM_SHUFFLE(S1, S2, S3, S4));
+				return _mm512_shuffle_epi32(a, static_cast<_MM_PERM_ENUM>(_MM_SHUFFLE(S1, S2, S3, S4)));
 			}
 
 			if constexpr (N == 64)


### PR DESCRIPTION
see https://github.com/RedSpah/xxhash_cpp/issues/39

This fixes compiling with -march=native (gcc 13) on my machine. This code needs double checking: I have no means to know if this fix works for all compilers/architectures.